### PR TITLE
Block web access to dotfiles and dotdirs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -30,6 +30,7 @@ RewriteRule .* - [L]
 Redirect permanent /socs/ /groups
 
 # Block any dotfiles (and implicitly /.git, /.github, etcetera)
+RewriteCond %{REQUEST_URI} !^/?\.well-known/
 RewriteRule (^|/)\. - [forbidden]
 
 # NB: there was historically a permanent redirect from webmail.srcf.net to www.srcf.net/squirrelmail

--- a/.htaccess
+++ b/.htaccess
@@ -29,6 +29,11 @@ RewriteRule .* - [L]
 
 Redirect permanent /socs/ /groups
 
+# Block Git things
+RewriteRule \.git([^/]*$|/) - [forbidden]
+RewriteRule \.github([^/]*$|/) - [forbidden]
+RewriteRule \.mailmap$ - [forbidden]
+
 # NB: there was historically a permanent redirect from webmail.srcf.net to www.srcf.net/squirrelmail
 # which we should expect users to cache indefinitely -- so keep this pointing at something useful
 RewriteRule ^squirrelmail(\.html)?(/.*)? https://www.srcf.net/webmail [R,L]

--- a/.htaccess
+++ b/.htaccess
@@ -29,10 +29,8 @@ RewriteRule .* - [L]
 
 Redirect permanent /socs/ /groups
 
-# Block Git things
-RewriteRule \.git([^/]*$|/) - [forbidden]
-RewriteRule \.github([^/]*$|/) - [forbidden]
-RewriteRule \.mailmap$ - [forbidden]
+# Block any dotfiles (and implicitly /.git, /.github, etcetera)
+RewriteRule (^|/)\. - [forbidden]
 
 # NB: there was historically a permanent redirect from webmail.srcf.net to www.srcf.net/squirrelmail
 # which we should expect users to cache indefinitely -- so keep this pointing at something useful

--- a/.htaccess
+++ b/.htaccess
@@ -30,7 +30,7 @@ RewriteRule .* - [L]
 Redirect permanent /socs/ /groups
 
 # Block any dotfiles (and implicitly /.git, /.github, etcetera)
-RewriteCond %{REQUEST_URI} !^/?\.well-known/
+RewriteCond %{REQUEST_URI} !^/\.well-known/
 RewriteRule (^|/)\. - [forbidden]
 
 # NB: there was historically a permanent redirect from webmail.srcf.net to www.srcf.net/squirrelmail


### PR DESCRIPTION
Even though the website is public, some content (e.g. WIP things) might not be meant for public consumption, and it's generally bad practice to expose your `.git` and related files on the web.

This change blocks access to:
  - `/.git/` and `/.github/`
  - files at the top of the web root with names starting in `.git`
  - `mailmap` (we don't have one currently, but may well do in future)

Can anyone else think of Git-related internal files we shouldn't expose?