### PR TITLE
hotfix: Correct URLs that previously used SSI variables

### DIFF
--- a/minutes/agm2021-03-20/index.html
+++ b/minutes/agm2021-03-20/index.html
@@ -53,12 +53,12 @@
       <h4 class="card-title">Committee Elections</h4>
       <p>The AGM will include the election of the SRCF Committee for 2021-22.</p>
       <p>Regardless of any prior involvement in the SRCF, we encourage you to stand for a committee position if you care about championing free and accessible computing for everyone at Cambridge</p>
-      <p>Rules on the election of the SRCF Committee are contained in Clause 5 of <a href="{{ DOMAIN_WEB }}/constitution">the constitution </a> and the most important points are reproduced below:</p>
+      <p>Rules on the election of the SRCF Committee are contained in Clause 5 of <a href="/constitution">the constitution </a> and the most important points are reproduced below:</p>
         <ul>
           <li>"Nominations must be submitted to the Secretary at least three days before the AGM (in the absence of other nominations for any post, nominations shall be accepted at the AGM for that post), either by email or on paper, to reach the Secretary by that deadline signed by proposer, seconder and nominee."</li>
           <li>"Any member of the society may be nominated for any Committee post (a proposer and seconder are needed). The Chair of the AGM shall appoint two tellers at the AGM."</li>
         </ul>
-      <p>If you are interested in running for any of the above positions, but you want to know more about what is involved, you might want to read our page about <a href="{{ DOMAIN_WEB }}/roles">roles in the SRCF</a>. Do not let the proposer and seconder requirement discourage you! If you send in a short manifesto/blurb explaining your motivation for standing for the position, the committee will be happy to propose/second you.</p>
+      <p>If you are interested in running for any of the above positions, but you want to know more about what is involved, you might want to read our page about <a href="/roles">roles in the SRCF</a>. Do not let the proposer and seconder requirement discourage you! If you send in a short manifesto/blurb explaining your motivation for standing for the position, the committee will be happy to propose/second you.</p>
     </div>
   </div>
 


### PR DESCRIPTION
Change URLs that were previously `{{ DOMMAIN_WEB }}/example_page` to `/example_page`