### PR TITLE
Replace AGM agenda page with minutes placeholder

### DIFF
--- a/minutes/agm2021-03-20/index.html
+++ b/minutes/agm2021-03-20/index.html
@@ -9,16 +9,15 @@
         <div class="card-body">
           <h4 class="card-title">Meeting details</h4>
           <p>The 2021 Annual General Meeting of the Student-Run Computing Facility
-            will be held during the final week of Lent term.</p>
-          <p>The meeting will commence at 14:00 GMT on Saturday 20 March 2021.</p>
-          <p>You will be able to join the AGM via Timeout at <a href="https://timeout.srcf.net/agm">https://timeout.srcf.net/agm</a>.</p>
+            took place from 14:00 GMT on Saturday 20 March 2021.</p>
+          <p>This page will be updated in due course with minutes from the meeting.</p>
         </div>
       </div>
     </div>
     <div class="col-md-6 d-flex align-items-stretch">
       <div class="card w-100">
         <div class="card-body">
-          <h4 class="card-title">Standing Agenda Items</h4>
+          <h4 class="card-title">Outline of minutes</h4>
           <ul>
             <li>Executive annual reports
               <ul>
@@ -27,11 +26,24 @@
                 <li>Sysadmins' report</li>
               </ul>
             </li>
-            <li>Consideration of received motions, if any</li>
-            <li>Election procedure
+            <li>Constitutional amendments
               <ul>
-                <li>Election candidates' speeches</li>
-                <li>Voting (procedure TBD)</li>
+                <li>Replacement of gendered pronouns (passed)</li>
+                <li>Removal of EGM venue requirements (withdrawn)</li>
+              </ul>
+            </li>
+            <li>Committee elections
+              <ul>
+                <li>Chair</li>
+                <li>Secretary</li>
+                <li>Junior Treasurer</li>
+                <li>Publicity Officer</li>
+              </ul>
+            </li>
+            <li>Any other business
+              <ul>
+                <li>Expression of thanks to the Computer Lab</li>
+                <li>Expression of thanks to core Timeout setup volunteers</li>
               </ul>
             </li>
           </ul>
@@ -40,38 +52,6 @@
     </div>
   </div>
 
-  <div class="card">
-    <div class="card-body">
-      <h4 class="card-title">Call for Submissions</h4>
-      <p>If you wish to stand for election to the committee, take a look at the dedicated section below.</p>
-      <p>If you have a motion for the AGM, please contact the Secretary at least three days in advance of the meeting date with details of the motion.  Examples of types of motion are resolutions to adopt a policy, mandates to the SRCF committee, or constitutional amendments.</p>
-    </div>
-  </div>
-
-  <div class="card">
-    <div class="card-body">
-      <h4 class="card-title">Committee Elections</h4>
-      <p>The AGM will include the election of the SRCF Committee for 2021-22.</p>
-      <p>Regardless of any prior involvement in the SRCF, we encourage you to stand for a committee position if you care about championing free and accessible computing for everyone at Cambridge</p>
-      <p>Rules on the election of the SRCF Committee are contained in Clause 5 of <a href="/constitution">the constitution </a> and the most important points are reproduced below:</p>
-        <ul>
-          <li>"Nominations must be submitted to the Secretary at least three days before the AGM (in the absence of other nominations for any post, nominations shall be accepted at the AGM for that post), either by email or on paper, to reach the Secretary by that deadline signed by proposer, seconder and nominee."</li>
-          <li>"Any member of the society may be nominated for any Committee post (a proposer and seconder are needed). The Chair of the AGM shall appoint two tellers at the AGM."</li>
-        </ul>
-      <p>If you are interested in running for any of the above positions, but you want to know more about what is involved, you might want to read our page about <a href="/roles">roles in the SRCF</a>. Do not let the proposer and seconder requirement discourage you! If you send in a short manifesto/blurb explaining your motivation for standing for the position, the committee will be happy to propose/second you.</p>
-    </div>
-  </div>
-
-  <div class="card">
-    <div class="card-body">
-      <h4 class="card-title">Other Notes</h4>
-      <ul>
-        <li>The Secretary can be contacted at <a href="mailto:secretary@srcf.net">secretary@srcf.net</a>.</li>
-        <li>If you cannot make the AGM, but still want to tell us something/help/contribute, please contact the committee at <a href="committee@srcf.net">committee@srcf.net</a>.</li>
-        <li>There are other ways to get involved in the SRCF. Interested sysadmins and volunteers are always needed. Contact <a href="mailto:sysadmins@srcf.net">sysadmins@srcf.net</a> to express your interest -- no prior involvement required.</li>
-      </ul>
-    </div>
-  </div>
 </div>
 
 <!--#include virtual="../../inc/footer.html" -->


### PR DESCRIPTION
Until @matiasilva has time to write up AGM minutes, let's put up a minimal placeholder page.

Reviews from the meeting chair (for general assent) and minutes-taker (to check that my outline is full and correct).