### PR TITLE
Bring vulnerable period forward by four hours

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,8 +128,8 @@
       <div class="card mb-3 shadow-sm">
         <div class="card-body">
           <h4 class="card-title">Scheduled vulnerable period</h4>
-          <p>To aid in security procedures, the SRCF has a potentially vulnerable period, <b>between 2am and 3am on
-              Sundays</b>. During this time the sysadmins may reboot the server without much prior warning.</p>
+          <p>To aid in security procedures, the SRCF has a potentially vulnerable period, <b>between 10pm and 11pm on
+              Saturdays</b>. During this time the sysadmins may reboot the server without much prior warning.</p>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -128,8 +128,8 @@
       <div class="card mb-3 shadow-sm">
         <div class="card-body">
           <h4 class="card-title">Scheduled vulnerable period</h4>
-          <p>To aid in security procedures, the SRCF has a potentially vulnerable period, <b>between 10pm and 11pm on
-              Saturdays</b>. During this time the sysadmins may reboot the server without much prior warning.</p>
+          <p>To aid in security procedures, the SRCF has a potentially vulnerable period, <b>from 10pm to 12 midnight on
+              Saturday nights</b>. During this time the sysadmins may reboot the server without much prior warning.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The sysadmins have been complaining that the vulnerable period is too late in the night for current preferences, so I've picked a time to bring it forward: an hour starting 10pm every Saturday, effectively four hours earlier than before.

Approvals requested from sysadmins as a form of agreement on this new time; if I get two of those I'll merge and make live.

Plan to also announce this to soc-srcf-maintenance, rolled into an email for another more important maintenance thing.