### PR TITLE
Don't imply that SRCF membership ends when leaving the university

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,7 +10,7 @@
 
 <p>The SRCF is the University of Cambridge's Student-Run Computing
 Facility. We provide web hosting, shell accounts and various other
-computing services to members of the University and groups such as
+computing services to members of the University (including alumni) and groups such as
 University societies. We are a University society, registered with
 the Junior Proctor. As such we are not formally supported by the 
 University Administration in any way; instead the service is maintained 

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
         <div class="card-body">
           <p>The Student-Run Computing Facility (SRCF) is a volunteer-run student society at the University
             of Cambridge. We run our own servers hosted in-house within the university and provide computing services
-            for thousands of staff and students.</p>
+            for thousands of staff, students, and alumni.</p>
           <a class="btn btn-primary" role="button" href="about">Learn what we do &raquo;</a>
         </div>
       </div>

--- a/services.html
+++ b/services.html
@@ -39,7 +39,7 @@ sysadmins</a>.</p>
           <li>Apache server-side includes and <em>.htaccess</em> files</li>
           <li>simple Raven authentication via <em>mod_ucam_webauth</em></li>
           <li>HTTPS certificates to secure your site</li>
-          <li>lifelong web address forwarding after you leave the university</li>
+          <li>lifelong web hosting</li>
         </ul>
       </div>
     </div>
@@ -57,7 +57,7 @@ sysadmins</a>.</p>
           <li>simple forwarding of mail to an external address</li>
           <li>additional addresses (e.g. <span class="var">CRSid</span>-<span class="var">something</span>@srcf.net) or advanced filtering via forwarding rules</li>
           <li>Mailman mailing lists, with <a href="https://lists.srcf.net/mailman">web-based administration</a></li>
-          <li>lifelong email forwarding after you leave the university</li>
+          <li>lifelong email hosting</li>
         </ul>
       </div>
     </div>
@@ -119,7 +119,7 @@ website.  We encourage individuals to become SRCF members in order to host a
 <a href="<!--#if expr="${domain_control}" --><!--#echo var="domain_control" --><!--#endif -->/signup/society">
 create a new group account</a>.  We recommend all group accounts name at
 least two administrators &ndash; this will help to maintain continuity of the
-account should one of the administrators leave the university.  Admins may be
+account should one of the administrators close their SRCF account.  Admins may be
 added or removed at any time, but new admins will need to sign up for a
 personal SRCF account if they don't already have one.</p>
 


### PR DESCRIPTION
Some language on https://www.srcf.net implies that membership of the SRCF and access to our services ends when leaving the university, which has been known to catch people out. This is an attempt to fix that.